### PR TITLE
feat: workspace 概念替代 notebook_path

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,9 +4,6 @@ OpsAgent — 数字运维员工
 一个实时在岗、会成长、在人类监督下工作的运维 Agent。
 
 用法:
-  # 安装命令行工具
-  pip install -e .
-
   # 初始化配置
   ops-agent init
 
@@ -22,7 +19,8 @@ OpsAgent — 数字运维员工
   # 只读模式（不执行任何修改）
   ops-agent --readonly
 
-  # 未安装时用 python main.py 替代 ops-agent
+  # 指定 workspace 目录
+  ops-agent --workspace /root/.ops-agent
 """
 
 import os
@@ -36,20 +34,34 @@ from src.infra.tools import TargetConfig
 # 重新导出 OpsAgent，保证 `from main import OpsAgent` 继续工作
 from src.core import OpsAgent  # noqa: F401
 
+# 默认 workspace 目录
+DEFAULT_WORKSPACE = "~/.ops-agent"
 
-def _load_dotenv():
-    """自动加载 notebook/.env 文件到环境变量（不覆盖已有值）"""
-    import sys
-    notebook = "./notebook"
-    # 从命令行参数获取 notebook 路径
-    for i, arg in enumerate(sys.argv):
-        if arg == "--notebook" and i + 1 < len(sys.argv):
-            notebook = sys.argv[i + 1]
-            break
 
-    env_path = Path(notebook) / ".env"
+def _resolve_workspace(args_workspace: str, args_notebook: str = "") -> str:
+    """解析 workspace 路径，--workspace 优先，--notebook 向后兼容"""
+    if args_workspace:
+        return str(Path(args_workspace).expanduser().resolve())
+    # 向后兼容：--notebook 指定时，推导 workspace 为其父目录（如果子目录名是 notebook）
+    if args_notebook:
+        nb = Path(args_notebook).expanduser().resolve()
+        if nb.name == "notebook":
+            return str(nb.parent)
+        # 否则 notebook_path 就是 workspace 本身（兼容旧用法）
+        return str(nb)
+    return str(Path(DEFAULT_WORKSPACE).expanduser().resolve())
+
+
+def _load_dotenv(workspace: str):
+    """自动加载 workspace/.env 文件到环境变量（不覆盖已有值）"""
+    env_path = Path(workspace) / ".env"
     if not env_path.exists():
-        return
+        # 向后兼容：尝试 notebook/.env
+        legacy_path = Path(workspace) / "notebook" / ".env"
+        if legacy_path.exists():
+            env_path = legacy_path
+        else:
+            return
 
     with open(env_path) as f:
         for line in f:
@@ -74,12 +86,29 @@ def _build_parser() -> argparse.ArgumentParser:
         "init", help="Interactive setup wizard",
         description="Generate config files with an interactive guide",
     )
-    init_parser.add_argument("--notebook", default="./notebook", help="Notebook 目录路径")
+    init_parser.add_argument("--workspace", default=DEFAULT_WORKSPACE,
+                             help="Workspace 根目录 (默认 ~/.ops-agent)")
+    init_parser.add_argument("--notebook", default="",
+                             help="[deprecated] 使用 --workspace 代替")
     init_parser.add_argument("--from-env", action="store_true",
                              help="Read all config from env vars, fail on missing")
 
+    # ── check 子命令 ──
+    check_parser = subparsers.add_parser(
+        "check", help="Config validation",
+    )
+    check_parser.add_argument("--workspace", default=DEFAULT_WORKSPACE,
+                              help="Workspace 根目录 (默认 ~/.ops-agent)")
+    check_parser.add_argument("--notebook", default="",
+                              help="[deprecated] 使用 --workspace 代替")
+    check_parser.add_argument("--test-llm", action="store_true",
+                              help="Test LLM connectivity")
+
     # ── 运行模式参数（无子命令时）──
-    parser.add_argument("--notebook", default="./notebook", help="Notebook 目录路径")
+    parser.add_argument("--workspace", default=DEFAULT_WORKSPACE,
+                        help="Workspace 根目录 (默认 ~/.ops-agent)")
+    parser.add_argument("--notebook", default="",
+                        help="[deprecated] 使用 --workspace 代替")
     parser.add_argument("--targets", default="",
                         help="targets.yaml 路径(多目标模式,推荐)")
     parser.add_argument("--target", default="",
@@ -95,9 +124,9 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def main():
-    # 手动解析以支持子命令和主参数共存
-    # 扫描 argv 查找子命令（支持子命令不在第一个位置的情况）
     import sys
+
+    # 扫描子命令
     subcmd = None
     skip_next = False
     for i, arg in enumerate(sys.argv[1:], 1):
@@ -108,53 +137,61 @@ def main():
             subcmd = arg
             break
         elif arg.startswith("-") and not arg.startswith("--from-env") and not arg.startswith("--test-llm"):
-            # 带 value 的 flag，跳过下一个参数
-            if arg in ("--notebook", "--targets", "--target", "--key", "--port",
+            if arg in ("--workspace", "--notebook", "--targets", "--target", "--key", "--port",
                        "--targets-file", "--model"):
                 skip_next = True
-            # boolean flags (--readonly, --debug, --password) 不需要跳过
-        else:
-            break  # unknown positional, stop
 
     if subcmd == "init":
         parser = argparse.ArgumentParser(description="ops-agent init")
         parser.add_argument("command", nargs="?", default="init")
-        parser.add_argument("--notebook", default="./notebook", help="Notebook 目录路径")
+        parser.add_argument("--workspace", default=DEFAULT_WORKSPACE,
+                            help="Workspace 根目录 (默认 ~/.ops-agent)")
+        parser.add_argument("--notebook", default="",
+                            help="[deprecated] 使用 --workspace 代替")
         parser.add_argument("--from-env", action="store_true",
                             help="Read all config from env vars, fail on missing")
         args = parser.parse_args()
+        workspace = _resolve_workspace(args.workspace, args.notebook)
         from src.init import run_init
-        run_init(notebook_path=args.notebook, from_env=args.from_env)
+        run_init(workspace_path=workspace, from_env=args.from_env)
         return
 
     if subcmd == "check":
         parser = argparse.ArgumentParser(description="ops-agent check")
         parser.add_argument("command", nargs="?", default="check")
-        parser.add_argument("--notebook", default="./notebook", help="Notebook 目录路径")
-        parser.add_argument("--test-llm", action="store_true", help="Test LLM connectivity")
+        parser.add_argument("--workspace", default=DEFAULT_WORKSPACE,
+                            help="Workspace 根目录 (默认 ~/.ops-agent)")
+        parser.add_argument("--notebook", default="",
+                            help="[deprecated] 使用 --workspace 代替")
+        parser.add_argument("--test-llm", action="store_true",
+                            help="Test LLM connectivity")
         args = parser.parse_args()
+        workspace = _resolve_workspace(args.workspace, args.notebook)
         from src.check import run_check
-        run_check(notebook_path=args.notebook, test_llm=args.test_llm)
+        run_check(workspace_path=workspace, test_llm=args.test_llm)
         return
 
-    # 自动加载 .env 文件
-    _load_dotenv()
-
+    # 主运行模式
     parser = _build_parser()
     args = parser.parse_args()
 
+    workspace = _resolve_workspace(args.workspace, args.notebook)
+
+    # 自动加载 .env 文件
+    _load_dotenv(workspace)
+
     if args.debug:
         logging.getLogger().setLevel(logging.DEBUG)
+
+    notebook_path = str(Path(workspace) / "notebook")
 
     # ── 加载目标 ──
     targets = []
     fallback = None
 
-    # 优先尝试 --targets yaml 文件
     targets_file = args.targets
     if not targets_file:
-        # 尝试默认路径 notebook/config/targets.yaml
-        default_path = Path(args.notebook) / "config" / "targets.yaml"
+        default_path = Path(notebook_path) / "config" / "targets.yaml"
         if default_path.exists():
             targets_file = str(default_path)
 
@@ -177,11 +214,11 @@ def main():
 
     if not targets and not fallback:
         fallback = TargetConfig.local()
-        print("ℹ️  未指定目标,使用本机模式。如需多目标请创建 notebook/config/targets.yaml")
+        print(f"ℹ️  未指定目标,使用本机模式。如需多目标请创建 {notebook_path}/config/targets.yaml")
 
     # 启动 Agent
     agent = OpsAgent(
-        notebook_path=args.notebook,
+        workspace_path=workspace,
         targets=targets,
         readonly=args.readonly,
         fallback_target=fallback,
@@ -197,7 +234,6 @@ def main():
     try:
         agent.run()
     finally:
-        # 确保终端状态恢复（防止 echo 丢失）
         from src.infra.chat import _restore_terminal
         _restore_terminal()
 

--- a/src/check.py
+++ b/src/check.py
@@ -3,10 +3,10 @@ ops-agent check — 配置校验
 
 用法:
   ops-agent check
-  ops-agent check --notebook ./notebook
+  ops-agent check --workspace /root/.ops-agent
 
 检查:
-1. notebook/.env — LLM 凭据是否存在
+1. .env — LLM 凭据是否存在 (workspace/.env)
 2. notebook/config/targets.yaml — 格式和必填字段
 3. notebook/config/limits.yaml — 格式和关键字段
 4. notebook/config/permissions.md — 是否存在
@@ -81,9 +81,14 @@ def _load_env_file(env_path: Path) -> dict:
     return env
 
 
-def check_env(notebook_path: str, result: CheckResult):
+def check_env(workspace: str, result: CheckResult):
     """检查 LLM 环境变量"""
-    env_path = Path(notebook_path) / ".env"
+    env_path = Path(workspace) / ".env"
+    # 向后兼容：workspace/notebook/.env
+    if not env_path.exists():
+        legacy = Path(workspace) / "notebook" / ".env"
+        if legacy.exists():
+            env_path = legacy
     env = _load_env_file(env_path)
 
     # 合并系统环境变量（系统优先）
@@ -280,8 +285,11 @@ def check_llm_connection(result: CheckResult):
         result.error(f"LLM 连通性测试失败: {e}")
 
 
-def run_check(notebook_path: str = "./notebook", test_llm: bool = False):
+def run_check(workspace_path: str = "~/.ops-agent", test_llm: bool = False):
     """运行完整校验"""
+    workspace = Path(workspace_path).expanduser().resolve()
+    notebook_path = str(workspace / "notebook")
+
     result = CheckResult()
 
     print()
@@ -290,14 +298,18 @@ def run_check(notebook_path: str = "./notebook", test_llm: bool = False):
     print()
 
     # 先加载 .env
-    env_path = Path(notebook_path) / ".env"
+    env_path = workspace / ".env"
+    if not env_path.exists():
+        legacy = workspace / "notebook" / ".env"
+        if legacy.exists():
+            env_path = legacy
     env = _load_env_file(env_path)
     for key, value in env.items():
         if key not in os.environ:
             os.environ[key] = value
 
     print("1. LLM 配置")
-    check_env(notebook_path, result)
+    check_env(str(workspace), result)
 
     print()
     print("2. 目标配置")

--- a/src/context_limits.py
+++ b/src/context_limits.py
@@ -106,7 +106,9 @@ def get_context_limits(notebook_path: str = "") -> ContextLimitsConfig:
         if notebook_path:
             path = os.path.join(notebook_path, "config", "context_limits.yaml")
         else:
-            path = "notebook/config/context_limits.yaml"
+            # 未提供 notebook_path 时尝试从默认 workspace 推导
+            ws = Path("~/.ops-agent").expanduser()
+            path = str(ws / "notebook" / "config" / "context_limits.yaml")
         _instance = ContextLimitsConfig.from_yaml(path)
     return _instance
 

--- a/src/core.py
+++ b/src/core.py
@@ -61,15 +61,17 @@ class OpsAgent(
         "incident": 2,
     }
 
-    def __init__(self, notebook_path: str, targets: list = None,
+    def __init__(self, workspace_path: str, targets: list = None,
                  readonly: bool = False, fallback_target=None):
         """
         参数:
-            notebook_path: Notebook 目录
+            workspace_path: Workspace 根目录
             targets: list[TargetConfig],多个目标。如果为空,使用 fallback_target
             readonly: 只读模式
             fallback_target: 当 targets 为空时的兜底目标(用于命令行 --target 启动)
         """
+        self.workspace_path = str(Path(workspace_path).resolve())
+        notebook_path = str(Path(workspace_path) / "notebook")
         self.llm = LLMClient()
         # Notebook 工厂：smart-notebook 已安装 → Smart，否则 → Basic
         self.notebook = create_notebook(notebook_path=notebook_path, llm=self.llm)

--- a/src/init.py
+++ b/src/init.py
@@ -4,7 +4,7 @@ ops-agent init — 交互式配置引导
 用法:
   python main.py init                     # 交互式
   python main.py init --from-env          # 全从环境变量读，缺了报错
-  python main.py init --notebook ./nb     # 指定 notebook 目录
+  python main.py init --workspace /root/.ops-agent  # 指定 workspace 目录
 
 环境变量映射（--from-env 模式 / Docker 部署）:
   OPS_LLM_PROVIDER        LLM 提供商 (anthropic/openai/zhipu)
@@ -38,6 +38,7 @@ TARGETS_FILE = "targets.yaml"
 LIMITS_FILE = "limits.yaml"
 PERMISSIONS_FILE = "permissions.md"
 NOTIFIER_FILE = "notifier.yaml"
+CONTEXT_LIMITS_FILE = "context_limits.yaml"
 
 LLM_PROVIDERS = {
     "anthropic": {"model": "claude-sonnet-4-20250514", "base_url": "", "env_key": "ANTHROPIC_API_KEY"},
@@ -296,6 +297,76 @@ type: none
     return "\n".join(lines)
 
 
+def _generate_context_limits_yaml() -> str:
+    """生成默认 context_limits.yaml"""
+    return """\
+# ═══════════════════════════════════════════════════════════════
+# OpsAgent 上下文窗口限制
+# ═══════════════════════════════════════════════════════════════
+#
+# 控制传入 LLM 的各类文本的最大字符数。
+# 所有值单位为字符数（除 tree_entries 为条目数）。
+# 修改后 Agent 下个循环周期自动生效。
+
+# ── 入职探索 ──
+explore_output_chars: 1000
+
+# ── 观测阶段 ──
+observe_output_chars: 1500
+max_observations_chars: 8000
+
+# ── 诊断阶段 ──
+playbook_search_chars: 500
+playbook_content_chars: 1500
+incident_history_chars: 1000
+source_context_trace_chars: 2000
+diagnosis_json_chars: 500
+prev_summary_chars: 1000
+
+# ── 补充收集 ──
+gap_output_incident_chars: 2000
+gap_output_trace_chars: 1500
+
+# ── 计划阶段 ──
+verify_action_desc_chars: 500
+verify_expected_chars: 300
+
+# ── 执行阶段 ──
+exec_result_chars: 6000
+exec_result_for_rediagnose_chars: 4000
+
+# ── 验证阶段 ──
+verify_state_chars: 2000
+verify_response_trace_chars: 500
+
+# ── 复盘阶段 ──
+reflect_incident_chars: 4000
+
+# ── 源码定位 ──
+source_location_render_chars: 2000
+source_function_snippet_chars: 4000
+
+# ── 自修复上下文 ──
+self_repair_log_chars: 8000
+self_repair_tree_entries: 200
+self_repair_incident_chars: 3000
+self_repair_config_chars: 4000
+self_repair_state_dump_chars: 3000
+
+# ── 补丁应用 ──
+patch_output_truncate_chars: 5000
+
+# ── 人类交互 ──
+show_file_preview_chars: 2000
+conversation_incident_chars: 3000
+
+# ── 项目地图 (AGENTS.md) ──
+agents_md_chars: 8000
+
+# ── 自修复输出 ──
+self_repair_output_tail_chars: 1500
+"""
+
 # ── 连通性测试 ──
 
 def _test_llm(provider: str, api_key: str, base_url: str, model: str) -> bool:
@@ -359,13 +430,15 @@ def _test_ssh(host: str, port: int = 22, key_file: str = "", password_env: str =
 
 # ── 主流程 ──
 
-def run_init(notebook_path: str = "./notebook", from_env: bool = False):
+def run_init(workspace_path: str = "~/.ops-agent", from_env: bool = False):
     """运行 init 引导"""
 
     if from_env:
         os.environ["OPS_INIT_FROM_ENV"] = "1"
 
-    config_dir = Path(notebook_path) / NOTEBOOK_CONFIG_DIR
+    workspace = Path(workspace_path).expanduser().resolve()
+    notebook_path = workspace / "notebook"
+    config_dir = notebook_path / NOTEBOOK_CONFIG_DIR
 
     # 检查已有配置
     targets_path = config_dir / TARGETS_FILE
@@ -379,6 +452,11 @@ def run_init(notebook_path: str = "./notebook", from_env: bool = False):
                 return
         else:
             print(f"⚠️  Overwriting existing {targets_path}")
+
+    # 创建 workspace 目录结构
+    for d in [config_dir, notebook_path / "playbook",
+              notebook_path / "lessons", workspace / "logs"]:
+        d.mkdir(parents=True, exist_ok=True)
 
     _print_banner()
 
@@ -575,12 +653,20 @@ def run_init(notebook_path: str = "./notebook", from_env: bool = False):
         notifier_path.write_text(_generate_notifier_yaml(notifier_type), encoding="utf-8")
         print(f"✅ {notifier_path}")
 
+    # context_limits.yaml — 只在不存在时生成
+    ctx_path = config_dir / CONTEXT_LIMITS_FILE
+    if not ctx_path.exists():
+        ctx_path.write_text(_generate_context_limits_yaml(), encoding="utf-8")
+        print(f"✅ {ctx_path}")
+    else:
+        print(f"ℹ️  {ctx_path} already exists, skipping")
+
     # ── 6. 持久化环境变量 ──
     print()
     print("━━━ Environment Variables ━━━")
 
-    # 写 .env 文件到 notebook 目录
-    env_path = Path(notebook_path) / ".env"
+    # 写 .env 文件到 workspace 根目录
+    env_path = workspace / ".env"
     env_lines = [
         f"OPS_LLM_PROVIDER={provider}",
         f"OPS_LLM_API_KEY={api_key}",
@@ -657,4 +743,4 @@ def run_init(notebook_path: str = "./notebook", from_env: bool = False):
     print()
     print("━━━ Next Steps ━━━")
     print(f"  1. Load env:  source {env_path}")
-    print(f"  2. Start:     ops-agent --notebook {notebook_path}")
+    print(f"  2. Start:     ops-agent --workspace {workspace}")


### PR DESCRIPTION
## 改动概述

引入 `--workspace` 替代 `--notebook`，统一所有路径基于 workspace 根目录解析。

### 改动文件

| 文件 | 改动 |
|------|------|
| `main.py` | `--workspace` 参数 + 向后兼容 `--notebook`；`.env` 从 workspace 根加载 |
| `src/core.py` | `__init__` 接收 `workspace_path`，内部推导 `notebook_path` |
| `src/init.py` | `workspace_path` 参数 + 生成 `context_limits.yaml` + `.env` 写 workspace 根 + 创建目录结构 |
| `src/check.py` | 适配 workspace_path，`.env` 优先从 workspace 根读 |
| `src/context_limits.py` | fallback 从 `~/.ops-agent` 推导而非相对路径 |

### 解决问题

- `context_limits.yaml not found` — cwd 不同导致相对路径解析错误
- `.env` 路径混淆 — `notebook/.env` vs `workspace/.env`
- init 漏生成 `context_limits.yaml`

### Workspace 目录结构

```
~/.ops-agent/          ← workspace root
├── .env               ← 环境变量（从 notebook/.env 迁移）
├── notebook/
│   ├── config/
│   │   ├── targets.yaml
│   │   ├── limits.yaml
│   │   ├── context_limits.yaml  ← init 现在会生成
│   │   ├── permissions.md
│   │   └── notifier.yaml
│   ├── playbook/
│   ├── lessons/
│   ├── audit/
│   └── state.json
└── logs/
```

### 升级

服务器上需要：
1. `pip install -e /opt/projects/smart-notebook` （在 venv 里）
2. `mv notebook/.env .env` （迁移 .env 到 workspace 根）
3. 启动命令改为 `python3 main.py --workspace /root/.ops-agent`