### PR TITLE
fix: _parse_plan 允许 COLLECT_MORE/ESCALATE 不含 steps 字段

### DIFF
--- a/src/agent/parsers.py
+++ b/src/agent/parsers.py
@@ -227,12 +227,17 @@ class ParsersMixin:
         from src.safety.trust import ActionPlan
 
         data = self._extract_json(response)
-        if not data or "steps" not in data:
+        if not data:
             logger.error(f"plan 输出不是合法 JSON, response={response[:500]}")
             return None
 
-        steps = data.get("steps", [])
+        # COLLECT_MORE / ESCALATE 可以没有 steps 字段
         next_action = data.get("next_action", "READY")
+        if "steps" not in data and next_action not in ("COLLECT_MORE", "ESCALATE"):
+            logger.error(f"plan JSON 缺少 steps 字段, response={response[:500]}")
+            return None
+
+        steps = data.get("steps", [])
         if not isinstance(steps, list) or (not steps and next_action not in ("COLLECT_MORE", "ESCALATE")):
             return None
 


### PR DESCRIPTION
## 问题

`_parse_plan` 中 `"steps" not in data` 检查在 `next_action` 判断之前，
当 LLM 正确返回 `{"next_action": "COLLECT_MORE", "gaps": [...]}` 时
（JSON 合法但不含 steps 字段），直接返回 None 触发 "plan JSON 解析失败" 重试。

v2.1.1 修复了 steps 为空列表的情况，但遗漏了 steps 字段完全不存在的情况。

## 改动

- `"steps" not in data` 检查与 `next_action` 结合：COLLECT_MORE/ESCALATE 允许缺少 steps
- 移除重复的 `next_action` 变量定义