### PR TITLE
fix: plan READY 但无有效 steps 时降级为 COLLECT_MORE

### DIFF
--- a/src/agent/parsers.py
+++ b/src/agent/parsers.py
@@ -253,10 +253,15 @@ class ParsersMixin:
             elif isinstance(s, str) and s.strip():
                 normalized_steps.append({"command": s.strip(), "purpose": "", "wait_seconds": 0})
 
-        # COLLECT_MORE / ESCALATE 时允许空 steps（只要 gaps 非空或有 escalate 理由）
+        # READY 时必须有可执行的 steps；COLLECT_MORE / ESCALATE 允许空
         next_action = data.get("next_action", "READY")
         if not normalized_steps and next_action not in ("COLLECT_MORE", "ESCALATE"):
-            return None
+            logger.warning(f"plan READY 但无有效 steps, 原始 steps={steps[:3]}, 降级为 COLLECT_MORE")
+            # 降级：如果 gaps 有内容，转为 COLLECT_MORE；否则返回 None 重试
+            if data.get("gaps"):
+                next_action = "COLLECT_MORE"
+            else:
+                return None
 
         # 规范化 rollback_steps
         rollback = []

--- a/src/agent/pipeline.py
+++ b/src/agent/pipeline.py
@@ -393,6 +393,14 @@ class PipelineMixin:
             break
 
         if plan:
+            # 防御：READY 但无有效 steps → 降级或返回 None
+            if plan.next_action == "READY" and not plan.steps:
+                logger.warning("plan READY 但无有效 steps，降级为 COLLECT_MORE 或重试")
+                self.chat.say("⚠️ 修复方案无有效步骤，重新收集信息", "warning")
+                if plan.gaps:
+                    plan.next_action = "COLLECT_MORE"
+                else:
+                    return None
             self.chat.say(
                 f"方案: {plan.action}  (L{plan.trust_level})",
                 "action",


### PR DESCRIPTION
## 问题

LLM 偶尔返回 `next_action=READY` 但 steps 为空或 command 无效，
导致控制台显示空的修复方案并请求人类批准：

```
我打算执行以下操作：
**理由**: ...
**修复步骤**:
**预期结果**: 
**信任等级**: L0
```

## 改动

双层防御：
1. **parsers.py** — `_parse_plan` 规范化后无有效 steps 时，如果有 gaps 则降级为 `COLLECT_MORE`，否则返回 None 触发重试
2. **pipeline.py** — `_plan` 返回后再次检查 `READY + 空 steps`，降级或返回 None

## 效果

- 不再展示空的修复方案
- LLM 信息不足时自动降级为 COLLECT_MORE 继续收集信息
- 无 gaps 且无 steps 时返回 None 触发 plan 重试