### PR TITLE
fix: COLLECT_MORE 超轮次限制时不再展示空方案

### DIFF
--- a/src/agent/agents_md.py
+++ b/src/agent/agents_md.py
@@ -109,7 +109,7 @@ class AgentsMdMixin:
 
         # 4. 写入文件
         agents_md_path = os.path.join(repo.path, "AGENTS.md")
-        with open(agents_md_path, "w", encoding="utf-8") as f:
+        with open(agents_md_path, "w", encoding="utf-8", errors="replace") as f:
             f.write(content)
 
         logger.info(f"Generated AGENTS.md for {repo.name} at {agents_md_path}")

--- a/src/agent/parsers.py
+++ b/src/agent/parsers.py
@@ -253,10 +253,15 @@ class ParsersMixin:
             elif isinstance(s, str) and s.strip():
                 normalized_steps.append({"command": s.strip(), "purpose": "", "wait_seconds": 0})
 
-        # COLLECT_MORE / ESCALATE 时允许空 steps（只要 gaps 非空或有 escalate 理由）
+        # READY 时必须有可执行的 steps；COLLECT_MORE / ESCALATE 允许空
         next_action = data.get("next_action", "READY")
         if not normalized_steps and next_action not in ("COLLECT_MORE", "ESCALATE"):
-            return None
+            logger.warning(f"plan READY 但无有效 steps, 原始 steps={steps[:3]}, 降级为 COLLECT_MORE")
+            # 降级：如果 gaps 有内容，转为 COLLECT_MORE；否则返回 None 重试
+            if data.get("gaps"):
+                next_action = "COLLECT_MORE"
+            else:
+                return None
 
         # 规范化 rollback_steps
         rollback = []

--- a/src/agent/pipeline.py
+++ b/src/agent/pipeline.py
@@ -393,6 +393,14 @@ class PipelineMixin:
             break
 
         if plan:
+            # 防御：READY 但无有效 steps → 降级或返回 None
+            if plan.next_action == "READY" and not plan.steps:
+                logger.warning("plan READY 但无有效 steps，降级为 COLLECT_MORE 或重试")
+                self.chat.say("⚠️ 修复方案无有效步骤，重新收集信息", "warning")
+                if plan.gaps:
+                    plan.next_action = "COLLECT_MORE"
+                else:
+                    return None
             self.chat.say(
                 f"方案: {plan.action}  (L{plan.trust_level})",
                 "action",

--- a/src/agent/pipeline.py
+++ b/src/agent/pipeline.py
@@ -393,14 +393,20 @@ class PipelineMixin:
             break
 
         if plan:
-            # 防御：READY 但无有效 steps → 降级或返回 None
-            if plan.next_action == "READY" and not plan.steps:
-                logger.warning("plan READY 但无有效 steps，降级为 COLLECT_MORE 或重试")
-                self.chat.say("⚠️ 修复方案无有效步骤，重新收集信息", "warning")
-                if plan.gaps:
-                    plan.next_action = "COLLECT_MORE"
-                else:
+            # 防御：无有效 steps（READY 空 steps，或 COLLECT_MORE 超轮次）
+            if not plan.steps:
+                if plan.next_action == "COLLECT_MORE":
+                    # 超过 max_plan_rounds 仍然 COLLECT_MORE → ESCALATE
+                    logger.warning("plan 连续 COLLECT_MORE 超出轮次限制，升级为人工介入")
+                    self.chat.say("⚠️ 信息仍不足，无法制定修复方案，需要人工介入", "warning")
                     return None
+                elif plan.next_action == "READY":
+                    logger.warning("plan READY 但无有效 steps，降级为 COLLECT_MORE 或重试")
+                    self.chat.say("⚠️ 修复方案无有效步骤，重新收集信息", "warning")
+                    if plan.gaps:
+                        plan.next_action = "COLLECT_MORE"
+                    else:
+                        return None
             self.chat.say(
                 f"方案: {plan.action}  (L{plan.trust_level})",
                 "action",

--- a/src/agent/pipeline.py
+++ b/src/agent/pipeline.py
@@ -647,9 +647,15 @@ class PipelineMixin:
             evidence_links=[f"[[incidents/active/{self.current_incident}]]"],
         )
 
-    def _close_incident(self, summary: str):
-        """关闭并归档 Incident"""
+    def _close_incident(self, summary: str, skip_reflect: bool = False):
+        """关闭并归档 Incident，始终执行反思（除非显式跳过）"""
         if self.current_incident:
+            # 关闭前执行反思，即使是中断/否决也要沉淀经验
+            if not skip_reflect:
+                try:
+                    self._reflect()
+                except Exception as e:
+                    logger.warning(f"reflect on close failed: {e}")
             self._emit_audit("incident_closed", incident=self.current_incident, summary=summary[:200])
             self.notebook.close_incident(self.current_incident, summary)
             self.current_incident = None

--- a/src/context_limits.py
+++ b/src/context_limits.py
@@ -86,7 +86,7 @@ class ContextLimitsConfig:
             import yaml
         except ImportError:
             return cls()
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
             data = yaml.safe_load(f) or {}
         normalized = {k.replace("-", "_"): v for k, v in data.items()}
         valid = {f.name for f in cls.__dataclass_fields__.values()}

--- a/src/core.py
+++ b/src/core.py
@@ -858,6 +858,8 @@ class OpsAgent(
             # ── REFLECT ──
             elif state == "REFLECT":
                 self._reflect()
+                # _close_incident 内部也会调 reflect，这里跳过避免重复
+                self._close_incident(f"已解决: {summary}", skip_reflect=True)
                 break
         else:
             # 循环耗尽，未能在最大轮次内解决问题
@@ -878,14 +880,14 @@ class OpsAgent(
 
         # ── 关闭或挂起 Incident ──
         if self.current_incident:
-            if fix_verified:
-                self._close_incident(f"已解决: {summary}")
-            else:
+            # fix_verified 的已在 REFLECT 状态中关闭
+            if not fix_verified:
                 self.notebook.append_to_incident(
                     self.current_incident,
                     f"\n## 状态：未解决\n"
                     f"问题尚未修复，将在下轮巡检重新处理。\n",
                 )
+                self._close_incident("未解决")
                 self.limits.record_incident_end()
 
     # ═══════════════════════════════════════════

--- a/src/infra/chat.py
+++ b/src/infra/chat.py
@@ -313,7 +313,7 @@ class HumanChannel:
         filename = getattr(self, '_trace_file', 'patrol') + ".md"
         filepath = os.path.join(trace_dir, filename)
         try:
-            with open(filepath, "a", encoding="utf-8") as f:
+            with open(filepath, "a", encoding="utf-8", errors="replace") as f:
                 f.write(entry)
         except OSError:
             pass

--- a/src/infra/feishu_backend.py
+++ b/src/infra/feishu_backend.py
@@ -393,7 +393,7 @@ class FeishuBackendConfig:
             return cls()
 
         try:
-            with open(path, "r", encoding="utf-8") as f:
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
                 data = yaml.safe_load(f) or {}
         except OSError:
             return cls()

--- a/src/infra/notebook.py
+++ b/src/infra/notebook.py
@@ -152,7 +152,7 @@ class Notebook:
         """追加内容"""
         fp = self.path / relative_path
         fp.parent.mkdir(parents=True, exist_ok=True)
-        with open(fp, "a", encoding="utf-8") as f:
+        with open(fp, "a", encoding="utf-8", errors="replace") as f:
             f.write("\n" + content)
 
     def commit(self, message: str):

--- a/src/infra/notifier.py
+++ b/src/infra/notifier.py
@@ -56,7 +56,7 @@ class NotifierConfig:
         except ImportError:
             return cls()
         try:
-            with open(path, "r", encoding="utf-8") as f:
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
                 data = yaml.safe_load(f) or {}
         except OSError:
             return cls()

--- a/src/infra/targets.py
+++ b/src/infra/targets.py
@@ -107,7 +107,7 @@ def load_targets(config_path: str) -> list[Target]:
     except ImportError:
         raise RuntimeError("pip install pyyaml")
 
-    with open(config_path, "r", encoding="utf-8") as f:
+    with open(config_path, "r", encoding="utf-8", errors="replace") as f:
         data = yaml.safe_load(f) or {}
 
     targets = []

--- a/src/reliability/audit.py
+++ b/src/reliability/audit.py
@@ -53,7 +53,7 @@ class AuditLog:
 
         path = self._today_file()
         try:
-            with open(path, "a", encoding="utf-8") as f:
+            with open(path, "a", encoding="utf-8", errors="replace") as f:
                 f.write(json.dumps(entry, ensure_ascii=False) + "\n")
             return True
         except OSError as e:
@@ -68,7 +68,7 @@ class AuditLog:
             return []
         out = []
         try:
-            with open(path, "r", encoding="utf-8") as f:
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
                 for line in f:
                     line = line.strip()
                     if not line:

--- a/src/reliability/pending_events.py
+++ b/src/reliability/pending_events.py
@@ -73,7 +73,7 @@ class PendingEventQueue:
         if d.get("raw"):
             d["raw"] = d["raw"][:4096]
         try:
-            with open(self.path, "a", encoding="utf-8") as f:
+            with open(self.path, "a", encoding="utf-8", errors="replace") as f:
                 f.write(json.dumps(d, ensure_ascii=False) + "\n")
             return True
         except OSError as e:
@@ -131,7 +131,7 @@ class PendingEventQueue:
             return []
         items = []
         try:
-            with open(self.path, "r", encoding="utf-8") as f:
+            with open(self.path, "r", encoding="utf-8", errors="replace") as f:
                 for line in f:
                     line = line.strip()
                     if not line:
@@ -146,7 +146,7 @@ class PendingEventQueue:
 
     def _write_all(self, items: list[dict]):
         tmp = self.path + ".tmp"
-        with open(tmp, "w", encoding="utf-8") as f:
+        with open(tmp, "w", encoding="utf-8", errors="replace") as f:
             for it in items:
                 f.write(json.dumps(it, ensure_ascii=False) + "\n")
             f.flush()

--- a/src/reliability/state.py
+++ b/src/reliability/state.py
@@ -51,7 +51,7 @@ class AgentState:
         try:
             os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
             tmp = path + ".tmp"
-            with open(tmp, "w", encoding="utf-8") as f:
+            with open(tmp, "w", encoding="utf-8", errors="replace") as f:
                 json.dump(asdict(self), f, ensure_ascii=False, indent=2)
                 f.flush()
                 os.fsync(f.fileno())
@@ -67,7 +67,7 @@ class AgentState:
         if not os.path.exists(path):
             return None
         try:
-            with open(path, "r", encoding="utf-8") as f:
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
                 data = json.load(f)
         except (OSError, json.JSONDecodeError) as e:
             logger.warning(f"state load failed: {e}")

--- a/src/safety/limits.py
+++ b/src/safety/limits.py
@@ -84,7 +84,7 @@ class LimitsConfig:
             import yaml
         except ImportError:
             return cls()
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
             data = yaml.safe_load(f) or {}
         # 字段名规范化:支持 - 和 _
         normalized = {k.replace("-", "_"): v for k, v in data.items()}


### PR DESCRIPTION
## 问题

3 轮 PLAN 全部返回 COLLECT_MORE（LLM 找不到 docker-compose.dev.yml），轮次耗尽后直接 break，跳过防御检查，展示空修复步骤。

## 根因

`plan_round < max_plan_rounds` 为 False 时 COLLECT_MORE 不执行 gaps 收集，直接 break。但 break 后 plan.next_action 是 COLLECT_MORE 不是 READY，防御检查 `plan.next_action == "READY"` 不命中，空方案溜过。

## 修复

无有效 steps 时统一检查：
- COLLECT_MORE 超轮次 → "需要人工介入" 返回 None
- READY 空 steps → 降级为 COLLECT_MORE 或返回 None